### PR TITLE
feat: Implement webhook support for event notifications

### DIFF
--- a/backend/internal/webhook/INTEGRATION.md
+++ b/backend/internal/webhook/INTEGRATION.md
@@ -1,0 +1,60 @@
+// Webhook Integration for main.go
+// 
+// Add this import to the imports section:
+//   "github.com/radhi1991/aran-mcp-sentinel/internal/webhook"
+//
+// Add this code after alertsHandler.RegisterRoutes(protected):
+
+// Webhook initialization code:
+/*
+	// Initialize webhook service
+	webhookRepo := webhook.NewRepository(dbConn.DB)
+	webhookService := webhook.NewService(webhookRepo, logger)
+	webhookHandler := webhook.NewHandler(webhookService, logger)
+	webhookHandler.RegisterRoutes(protected)
+
+	// Start webhook retry processor
+	webhookCtx, webhookCancel := context.WithCancel(context.Background())
+	defer webhookCancel()
+	go func() {
+		ticker := time.NewTicker(1 * time.Minute)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-webhookCtx.Done():
+				return
+			case <-ticker.C:
+				if err := webhookService.ProcessRetries(webhookCtx); err != nil {
+					logger.Error("Failed to process webhook retries", zap.Error(err))
+				}
+			}
+		}
+	}()
+	logger.Info("Started webhook retry processor", zap.Duration("interval", 1*time.Minute))
+*/
+
+// Example usage from other services to trigger webhooks:
+/*
+	// In monitoring/alerts handler when an alert is created:
+	webhookService.TriggerEvent(ctx, orgID, webhook.EventAlertCreated, map[string]interface{}{
+		"alert_id": alert.ID,
+		"title":    alert.Title,
+		"severity": alert.Severity,
+		"message":  alert.Message,
+	})
+
+	// In MCP handler when a server status changes:
+	webhookService.TriggerEvent(ctx, orgID, webhook.EventServerStatusDown, map[string]interface{}{
+		"server_id":   server.ID,
+		"server_name": server.Name,
+		"status":      "down",
+		"error":       errorMsg,
+	})
+
+	// In security handler when a scan completes:
+	webhookService.TriggerEvent(ctx, orgID, webhook.EventSecurityScanCompleted, map[string]interface{}{
+		"scan_id":        scan.ID,
+		"vulnerabilities": vulnerabilityCount,
+		"score":          securityScore,
+	})
+*/

--- a/backend/internal/webhook/client.go
+++ b/backend/internal/webhook/client.go
@@ -1,0 +1,140 @@
+package webhook
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// Client provides methods for verifying incoming webhooks and sending webhook-style requests
+type Client struct {
+	secret string
+}
+
+// NewClient creates a new webhook client for verification
+func NewClient(secret string) *Client {
+	return &Client{secret: secret}
+}
+
+// VerifyRequest verifies an incoming webhook request
+func (c *Client) VerifyRequest(r *http.Request) error {
+	signature := r.Header.Get("X-Webhook-Signature")
+	timestampStr := r.Header.Get("X-Webhook-Timestamp")
+
+	if signature == "" || timestampStr == "" {
+		return fmt.Errorf("missing signature or timestamp headers")
+	}
+
+	timestamp, err := strconv.ParseInt(timestampStr, 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid timestamp: %w", err)
+	}
+
+	// Check timestamp is within 5 minutes (replay attack prevention)
+	age := time.Since(time.Unix(timestamp, 0))
+	if age > 5*time.Minute || age < -5*time.Minute {
+		return fmt.Errorf("timestamp too old or too far in the future: %v", age)
+	}
+
+	// Read body
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read body: %w", err)
+	}
+	// Restore body for downstream handlers
+	r.Body = io.NopCloser(bytes.NewReader(body))
+
+	// Verify signature
+	if !VerifySignature(c.secret, signature, timestamp, body) {
+		return fmt.Errorf("signature verification failed")
+	}
+
+	return nil
+}
+
+// VerifyMiddleware returns an HTTP middleware that verifies webhook signatures
+func (c *Client) VerifyMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := c.VerifyRequest(r); err != nil {
+			http.Error(w, fmt.Sprintf("Webhook verification failed: %v", err), http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// ParsePayload parses the webhook payload from the request
+func ParsePayload(r *http.Request) (*WebhookPayload, error) {
+	var payload WebhookPayload
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		return nil, fmt.Errorf("failed to decode payload: %w", err)
+	}
+	return &payload, nil
+}
+
+// SignRequest signs an outgoing webhook request
+func SignRequest(secret string, req *http.Request, body []byte) {
+	timestamp := time.Now().Unix()
+	signature := GenerateSignature(secret, timestamp, body)
+
+	req.Header.Set("X-Webhook-Signature", signature)
+	req.Header.Set("X-Webhook-Timestamp", strconv.FormatInt(timestamp, 10))
+}
+
+// ComputeSignature computes a webhook signature for a payload
+// This is useful for implementing custom webhook sending
+func ComputeSignature(secret string, payload []byte) (signature string, timestamp int64) {
+	timestamp = time.Now().Unix()
+	data := fmt.Sprintf("%d.%s", timestamp, string(payload))
+	h := hmac.New(sha256.New, []byte(secret))
+	h.Write([]byte(data))
+	signature = "sha256=" + hex.EncodeToString(h.Sum(nil))
+	return
+}
+
+// Example verification code for webhook receivers:
+/*
+package main
+
+import (
+	"fmt"
+	"net/http"
+	
+	"github.com/radhi1991/aran-mcp-sentinel/internal/webhook"
+)
+
+func main() {
+	secret := "your-webhook-secret"
+	client := webhook.NewClient(secret)
+
+	http.HandleFunc("/webhook", func(w http.ResponseWriter, r *http.Request) {
+		// Verify the webhook signature
+		if err := client.VerifyRequest(r); err != nil {
+			http.Error(w, "Invalid signature", http.StatusUnauthorized)
+			return
+		}
+
+		// Parse the payload
+		payload, err := webhook.ParsePayload(r)
+		if err != nil {
+			http.Error(w, "Invalid payload", http.StatusBadRequest)
+			return
+		}
+
+		// Handle the event
+		fmt.Printf("Received event: %s\n", payload.Event)
+		fmt.Printf("Data: %+v\n", payload.Data)
+
+		w.WriteHeader(http.StatusOK)
+	})
+
+	http.ListenAndServe(":8080", nil)
+}
+*/

--- a/backend/internal/webhook/models.go
+++ b/backend/internal/webhook/models.go
@@ -1,0 +1,193 @@
+package webhook
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// EventType represents the type of webhook event
+type EventType string
+
+const (
+	// Server events
+	EventServerCreated     EventType = "server.created"
+	EventServerUpdated     EventType = "server.updated"
+	EventServerDeleted     EventType = "server.deleted"
+	EventServerStatusUp    EventType = "server.status.up"
+	EventServerStatusDown  EventType = "server.status.down"
+
+	// Alert events
+	EventAlertCreated      EventType = "alert.created"
+	EventAlertResolved     EventType = "alert.resolved"
+
+	// Security events
+	EventSecurityScanStarted   EventType = "security.scan.started"
+	EventSecurityScanCompleted EventType = "security.scan.completed"
+	EventVulnerabilityFound    EventType = "security.vulnerability.found"
+
+	// Discovery events
+	EventDiscoveryStarted   EventType = "discovery.started"
+	EventDiscoveryCompleted EventType = "discovery.completed"
+	EventServerDiscovered   EventType = "discovery.server.found"
+)
+
+// AllEventTypes returns all available event types
+func AllEventTypes() []EventType {
+	return []EventType{
+		EventServerCreated,
+		EventServerUpdated,
+		EventServerDeleted,
+		EventServerStatusUp,
+		EventServerStatusDown,
+		EventAlertCreated,
+		EventAlertResolved,
+		EventSecurityScanStarted,
+		EventSecurityScanCompleted,
+		EventVulnerabilityFound,
+		EventDiscoveryStarted,
+		EventDiscoveryCompleted,
+		EventServerDiscovered,
+	}
+}
+
+// DeliveryStatus represents the status of a webhook delivery
+type DeliveryStatus string
+
+const (
+	DeliveryStatusPending   DeliveryStatus = "pending"
+	DeliveryStatusSuccess   DeliveryStatus = "success"
+	DeliveryStatusFailed    DeliveryStatus = "failed"
+	DeliveryStatusRetrying  DeliveryStatus = "retrying"
+)
+
+// StringArray is a helper type for PostgreSQL text arrays
+type StringArray []string
+
+func (a StringArray) Value() (driver.Value, error) {
+	if a == nil {
+		return nil, nil
+	}
+	return json.Marshal(a)
+}
+
+func (a *StringArray) Scan(value interface{}) error {
+	if value == nil {
+		*a = nil
+		return nil
+	}
+	bytes, ok := value.([]byte)
+	if !ok {
+		return json.Unmarshal([]byte(value.(string)), a)
+	}
+	return json.Unmarshal(bytes, a)
+}
+
+// Webhook represents a webhook configuration
+type Webhook struct {
+	ID             uuid.UUID   `db:"id" json:"id"`
+	OrganizationID uuid.UUID   `db:"organization_id" json:"organization_id"`
+	Name           string      `db:"name" json:"name"`
+	URL            string      `db:"url" json:"url"`
+	Secret         string      `db:"secret" json:"-"` // Never expose in JSON
+	Events         StringArray `db:"events" json:"events"`
+	Headers        JSONB       `db:"headers" json:"headers,omitempty"`
+	IsActive       bool        `db:"is_active" json:"is_active"`
+	Description    *string     `db:"description" json:"description,omitempty"`
+	CreatedBy      *uuid.UUID  `db:"created_by" json:"created_by,omitempty"`
+	CreatedAt      time.Time   `db:"created_at" json:"created_at"`
+	UpdatedAt      time.Time   `db:"updated_at" json:"updated_at"`
+	DeletedAt      *time.Time  `db:"deleted_at" json:"deleted_at,omitempty"`
+}
+
+// WebhookDelivery represents a single webhook delivery attempt
+type WebhookDelivery struct {
+	ID              uuid.UUID       `db:"id" json:"id"`
+	WebhookID       uuid.UUID       `db:"webhook_id" json:"webhook_id"`
+	Event           string          `db:"event" json:"event"`
+	Payload         JSONB           `db:"payload" json:"payload"`
+	Status          DeliveryStatus  `db:"status" json:"status"`
+	StatusCode      *int            `db:"status_code" json:"status_code,omitempty"`
+	Response        *string         `db:"response" json:"response,omitempty"`
+	ErrorMessage    *string         `db:"error_message" json:"error_message,omitempty"`
+	Attempts        int             `db:"attempts" json:"attempts"`
+	NextRetryAt     *time.Time      `db:"next_retry_at" json:"next_retry_at,omitempty"`
+	DeliveredAt     *time.Time      `db:"delivered_at" json:"delivered_at,omitempty"`
+	DurationMs      *int            `db:"duration_ms" json:"duration_ms,omitempty"`
+	CreatedAt       time.Time       `db:"created_at" json:"created_at"`
+	UpdatedAt       time.Time       `db:"updated_at" json:"updated_at"`
+}
+
+// JSONB represents a JSONB field
+type JSONB map[string]interface{}
+
+func (j JSONB) Value() (driver.Value, error) {
+	if j == nil {
+		return nil, nil
+	}
+	return json.Marshal(j)
+}
+
+func (j *JSONB) Scan(value interface{}) error {
+	if value == nil {
+		*j = nil
+		return nil
+	}
+	bytes, ok := value.([]byte)
+	if !ok {
+		return json.Unmarshal([]byte(value.(string)), j)
+	}
+	return json.Unmarshal(bytes, j)
+}
+
+// CreateWebhookRequest represents the request to create a webhook
+type CreateWebhookRequest struct {
+	Name        string            `json:"name" validate:"required,min=1,max=255"`
+	URL         string            `json:"url" validate:"required,url"`
+	Events      []string          `json:"events" validate:"required,min=1"`
+	Headers     map[string]string `json:"headers,omitempty"`
+	Description *string           `json:"description,omitempty"`
+	IsActive    *bool             `json:"is_active,omitempty"`
+}
+
+// UpdateWebhookRequest represents the request to update a webhook
+type UpdateWebhookRequest struct {
+	Name        *string           `json:"name,omitempty" validate:"omitempty,min=1,max=255"`
+	URL         *string           `json:"url,omitempty" validate:"omitempty,url"`
+	Events      []string          `json:"events,omitempty"`
+	Headers     map[string]string `json:"headers,omitempty"`
+	Description *string           `json:"description,omitempty"`
+	IsActive    *bool             `json:"is_active,omitempty"`
+}
+
+// WebhookResponse represents the API response for a webhook
+type WebhookResponse struct {
+	ID             uuid.UUID         `json:"id"`
+	OrganizationID uuid.UUID         `json:"organization_id"`
+	Name           string            `json:"name"`
+	URL            string            `json:"url"`
+	Events         []string          `json:"events"`
+	Headers        map[string]string `json:"headers,omitempty"`
+	IsActive       bool              `json:"is_active"`
+	Description    *string           `json:"description,omitempty"`
+	CreatedAt      time.Time         `json:"created_at"`
+	UpdatedAt      time.Time         `json:"updated_at"`
+	// Include secret only once on creation
+	Secret         string            `json:"secret,omitempty"`
+}
+
+// WebhookPayload represents the payload sent to webhooks
+type WebhookPayload struct {
+	ID        string                 `json:"id"`
+	Event     EventType              `json:"event"`
+	Timestamp time.Time              `json:"timestamp"`
+	Data      map[string]interface{} `json:"data"`
+}
+
+// WebhookTestRequest represents a test webhook request
+type WebhookTestRequest struct {
+	Event EventType              `json:"event,omitempty"`
+	Data  map[string]interface{} `json:"data,omitempty"`
+}

--- a/backend/internal/webhook/repository.go
+++ b/backend/internal/webhook/repository.go
@@ -1,0 +1,240 @@
+package webhook
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+)
+
+// Repository handles webhook database operations
+type Repository struct {
+	db *sqlx.DB
+}
+
+// NewRepository creates a new webhook repository
+func NewRepository(db *sqlx.DB) *Repository {
+	return &Repository{db: db}
+}
+
+// Create creates a new webhook
+func (r *Repository) Create(ctx context.Context, webhook *Webhook) error {
+	query := `
+		INSERT INTO webhooks (id, organization_id, name, url, secret, events, headers, is_active, description, created_by, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+	`
+	_, err := r.db.ExecContext(ctx, query,
+		webhook.ID,
+		webhook.OrganizationID,
+		webhook.Name,
+		webhook.URL,
+		webhook.Secret,
+		webhook.Events,
+		webhook.Headers,
+		webhook.IsActive,
+		webhook.Description,
+		webhook.CreatedBy,
+		webhook.CreatedAt,
+		webhook.UpdatedAt,
+	)
+	return err
+}
+
+// GetByID retrieves a webhook by ID
+func (r *Repository) GetByID(ctx context.Context, id uuid.UUID) (*Webhook, error) {
+	var webhook Webhook
+	query := `
+		SELECT id, organization_id, name, url, secret, events, headers, is_active, description, created_by, created_at, updated_at, deleted_at
+		FROM webhooks
+		WHERE id = $1 AND deleted_at IS NULL
+	`
+	err := r.db.GetContext(ctx, &webhook, query, id)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	return &webhook, err
+}
+
+// GetByOrganization retrieves all webhooks for an organization
+func (r *Repository) GetByOrganization(ctx context.Context, orgID uuid.UUID) ([]Webhook, error) {
+	var webhooks []Webhook
+	query := `
+		SELECT id, organization_id, name, url, secret, events, headers, is_active, description, created_by, created_at, updated_at, deleted_at
+		FROM webhooks
+		WHERE organization_id = $1 AND deleted_at IS NULL
+		ORDER BY created_at DESC
+	`
+	err := r.db.SelectContext(ctx, &webhooks, query, orgID)
+	return webhooks, err
+}
+
+// GetActiveByEvent retrieves all active webhooks subscribed to an event
+func (r *Repository) GetActiveByEvent(ctx context.Context, orgID uuid.UUID, event EventType) ([]Webhook, error) {
+	var webhooks []Webhook
+	query := `
+		SELECT id, organization_id, name, url, secret, events, headers, is_active, description, created_by, created_at, updated_at, deleted_at
+		FROM webhooks
+		WHERE organization_id = $1 
+		  AND is_active = true 
+		  AND deleted_at IS NULL
+		  AND events @> $2::jsonb
+		ORDER BY created_at ASC
+	`
+	// Convert event to JSON array element for containment check
+	eventJSON := fmt.Sprintf(`["%s"]`, event)
+	err := r.db.SelectContext(ctx, &webhooks, query, orgID, eventJSON)
+	return webhooks, err
+}
+
+// Update updates a webhook
+func (r *Repository) Update(ctx context.Context, webhook *Webhook) error {
+	query := `
+		UPDATE webhooks
+		SET name = $2, url = $3, events = $4, headers = $5, is_active = $6, description = $7, updated_at = $8
+		WHERE id = $1 AND deleted_at IS NULL
+	`
+	_, err := r.db.ExecContext(ctx, query,
+		webhook.ID,
+		webhook.Name,
+		webhook.URL,
+		webhook.Events,
+		webhook.Headers,
+		webhook.IsActive,
+		webhook.Description,
+		webhook.UpdatedAt,
+	)
+	return err
+}
+
+// Delete soft-deletes a webhook
+func (r *Repository) Delete(ctx context.Context, id uuid.UUID) error {
+	query := `UPDATE webhooks SET deleted_at = $2, updated_at = $2 WHERE id = $1 AND deleted_at IS NULL`
+	_, err := r.db.ExecContext(ctx, query, id, time.Now())
+	return err
+}
+
+// RotateSecret generates and sets a new secret for a webhook
+func (r *Repository) RotateSecret(ctx context.Context, id uuid.UUID, newSecret string) error {
+	query := `UPDATE webhooks SET secret = $2, updated_at = $3 WHERE id = $1 AND deleted_at IS NULL`
+	_, err := r.db.ExecContext(ctx, query, id, newSecret, time.Now())
+	return err
+}
+
+// CreateDelivery creates a new webhook delivery record
+func (r *Repository) CreateDelivery(ctx context.Context, delivery *WebhookDelivery) error {
+	query := `
+		INSERT INTO webhook_deliveries (id, webhook_id, event, payload, status, attempts, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+	`
+	_, err := r.db.ExecContext(ctx, query,
+		delivery.ID,
+		delivery.WebhookID,
+		delivery.Event,
+		delivery.Payload,
+		delivery.Status,
+		delivery.Attempts,
+		delivery.CreatedAt,
+		delivery.UpdatedAt,
+	)
+	return err
+}
+
+// UpdateDelivery updates a webhook delivery
+func (r *Repository) UpdateDelivery(ctx context.Context, delivery *WebhookDelivery) error {
+	query := `
+		UPDATE webhook_deliveries
+		SET status = $2, status_code = $3, response = $4, error_message = $5, attempts = $6, 
+		    next_retry_at = $7, delivered_at = $8, duration_ms = $9, updated_at = $10
+		WHERE id = $1
+	`
+	_, err := r.db.ExecContext(ctx, query,
+		delivery.ID,
+		delivery.Status,
+		delivery.StatusCode,
+		delivery.Response,
+		delivery.ErrorMessage,
+		delivery.Attempts,
+		delivery.NextRetryAt,
+		delivery.DeliveredAt,
+		delivery.DurationMs,
+		delivery.UpdatedAt,
+	)
+	return err
+}
+
+// GetDeliveryByID retrieves a delivery by ID
+func (r *Repository) GetDeliveryByID(ctx context.Context, id uuid.UUID) (*WebhookDelivery, error) {
+	var delivery WebhookDelivery
+	query := `
+		SELECT id, webhook_id, event, payload, status, status_code, response, error_message, 
+		       attempts, next_retry_at, delivered_at, duration_ms, created_at, updated_at
+		FROM webhook_deliveries
+		WHERE id = $1
+	`
+	err := r.db.GetContext(ctx, &delivery, query, id)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	return &delivery, err
+}
+
+// GetDeliveriesByWebhook retrieves deliveries for a webhook
+func (r *Repository) GetDeliveriesByWebhook(ctx context.Context, webhookID uuid.UUID, limit int) ([]WebhookDelivery, error) {
+	var deliveries []WebhookDelivery
+	query := `
+		SELECT id, webhook_id, event, payload, status, status_code, response, error_message, 
+		       attempts, next_retry_at, delivered_at, duration_ms, created_at, updated_at
+		FROM webhook_deliveries
+		WHERE webhook_id = $1
+		ORDER BY created_at DESC
+		LIMIT $2
+	`
+	err := r.db.SelectContext(ctx, &deliveries, query, webhookID, limit)
+	return deliveries, err
+}
+
+// GetPendingRetries retrieves deliveries that need to be retried
+func (r *Repository) GetPendingRetries(ctx context.Context, limit int) ([]WebhookDelivery, error) {
+	var deliveries []WebhookDelivery
+	query := `
+		SELECT id, webhook_id, event, payload, status, status_code, response, error_message, 
+		       attempts, next_retry_at, delivered_at, duration_ms, created_at, updated_at
+		FROM webhook_deliveries
+		WHERE status IN ('pending', 'retrying') 
+		  AND (next_retry_at IS NULL OR next_retry_at <= NOW())
+		  AND attempts < 5
+		ORDER BY created_at ASC
+		LIMIT $1
+	`
+	err := r.db.SelectContext(ctx, &deliveries, query, limit)
+	return deliveries, err
+}
+
+// GetDeliveryStats retrieves delivery statistics for a webhook
+func (r *Repository) GetDeliveryStats(ctx context.Context, webhookID uuid.UUID, since time.Time) (*DeliveryStats, error) {
+	var stats DeliveryStats
+	query := `
+		SELECT 
+			COUNT(*) as total,
+			COUNT(*) FILTER (WHERE status = 'success') as successful,
+			COUNT(*) FILTER (WHERE status = 'failed') as failed,
+			COUNT(*) FILTER (WHERE status IN ('pending', 'retrying')) as pending,
+			AVG(duration_ms) FILTER (WHERE duration_ms IS NOT NULL) as avg_duration_ms
+		FROM webhook_deliveries
+		WHERE webhook_id = $1 AND created_at >= $2
+	`
+	err := r.db.GetContext(ctx, &stats, query, webhookID, since)
+	return &stats, err
+}
+
+// DeliveryStats represents webhook delivery statistics
+type DeliveryStats struct {
+	Total         int      `db:"total" json:"total"`
+	Successful    int      `db:"successful" json:"successful"`
+	Failed        int      `db:"failed" json:"failed"`
+	Pending       int      `db:"pending" json:"pending"`
+	AvgDurationMs *float64 `db:"avg_duration_ms" json:"avg_duration_ms,omitempty"`
+}

--- a/backend/internal/webhook/webhook_test.go
+++ b/backend/internal/webhook/webhook_test.go
@@ -1,0 +1,160 @@
+package webhook
+
+import (
+	"testing"
+	"time"
+)
+
+func TestGenerateAndVerifySignature(t *testing.T) {
+	secret := "test-secret-key-12345"
+	payload := []byte(`{"event":"test.event","data":{"message":"hello"}}`)
+	timestamp := time.Now().Unix()
+
+	// Generate signature
+	signature := GenerateSignature(secret, timestamp, payload)
+
+	// Verify the signature
+	if !VerifySignature(secret, signature, timestamp, payload) {
+		t.Error("Signature verification failed for valid signature")
+	}
+
+	// Test with wrong secret
+	if VerifySignature("wrong-secret", signature, timestamp, payload) {
+		t.Error("Signature verification should fail with wrong secret")
+	}
+
+	// Test with tampered payload
+	tamperedPayload := []byte(`{"event":"test.event","data":{"message":"tampered"}}`)
+	if VerifySignature(secret, signature, timestamp, tamperedPayload) {
+		t.Error("Signature verification should fail with tampered payload")
+	}
+
+	// Test with wrong timestamp
+	if VerifySignature(secret, signature, timestamp+1, payload) {
+		t.Error("Signature verification should fail with wrong timestamp")
+	}
+}
+
+func TestGenerateSecret(t *testing.T) {
+	secret1, err := GenerateSecret()
+	if err != nil {
+		t.Fatalf("GenerateSecret failed: %v", err)
+	}
+
+	if len(secret1) != 64 { // 32 bytes = 64 hex chars
+		t.Errorf("Expected secret length 64, got %d", len(secret1))
+	}
+
+	// Generate another secret and ensure they're different
+	secret2, err := GenerateSecret()
+	if err != nil {
+		t.Fatalf("GenerateSecret failed: %v", err)
+	}
+
+	if secret1 == secret2 {
+		t.Error("Generated secrets should be unique")
+	}
+}
+
+func TestAllEventTypes(t *testing.T) {
+	events := AllEventTypes()
+	if len(events) == 0 {
+		t.Error("AllEventTypes should return at least one event type")
+	}
+
+	// Check for expected events
+	expectedEvents := []EventType{
+		EventServerCreated,
+		EventServerStatusDown,
+		EventAlertCreated,
+		EventSecurityScanCompleted,
+	}
+
+	eventSet := make(map[EventType]bool)
+	for _, e := range events {
+		eventSet[e] = true
+	}
+
+	for _, expected := range expectedEvents {
+		if !eventSet[expected] {
+			t.Errorf("Expected event type %s not found", expected)
+		}
+	}
+}
+
+func TestRetryDelays(t *testing.T) {
+	if len(RetryDelays) != 5 {
+		t.Errorf("Expected 5 retry delays, got %d", len(RetryDelays))
+	}
+
+	// Ensure delays are increasing
+	for i := 1; i < len(RetryDelays); i++ {
+		if RetryDelays[i] <= RetryDelays[i-1] {
+			t.Errorf("Retry delays should be increasing: %v <= %v at index %d",
+				RetryDelays[i], RetryDelays[i-1], i)
+		}
+	}
+}
+
+func TestWebhookToResponse(t *testing.T) {
+	webhook := &Webhook{
+		ID:             [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+		OrganizationID: [16]byte{16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1},
+		Name:           "Test Webhook",
+		URL:            "https://example.com/webhook",
+		Secret:         "secret-should-not-appear",
+		Events:         []string{"server.created", "alert.created"},
+		Headers:        JSONB{"Authorization": "Bearer token"},
+		IsActive:       true,
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+
+	response := webhookToResponse(webhook)
+
+	if response.Name != webhook.Name {
+		t.Errorf("Expected name %s, got %s", webhook.Name, response.Name)
+	}
+
+	if response.Secret != "" {
+		t.Error("Secret should not be included in response")
+	}
+
+	if response.URL != webhook.URL {
+		t.Errorf("Expected URL %s, got %s", webhook.URL, response.URL)
+	}
+}
+
+func TestConvertHeaders(t *testing.T) {
+	headers := map[string]string{
+		"Authorization": "Bearer token",
+		"X-Custom":      "value",
+	}
+
+	jsonb := convertHeaders(headers)
+
+	if jsonb["Authorization"] != "Bearer token" {
+		t.Error("Header conversion failed")
+	}
+
+	// Test nil headers
+	nilHeaders := convertHeaders(nil)
+	if nilHeaders != nil {
+		t.Error("Nil headers should return nil JSONB")
+	}
+}
+
+func TestDeliveryStatusConstants(t *testing.T) {
+	statuses := []DeliveryStatus{
+		DeliveryStatusPending,
+		DeliveryStatusSuccess,
+		DeliveryStatusFailed,
+		DeliveryStatusRetrying,
+	}
+
+	for _, s := range statuses {
+		if s == "" {
+			t.Error("Delivery status should not be empty")
+		}
+	}
+}

--- a/backend/migrations/003_add_webhooks.sql
+++ b/backend/migrations/003_add_webhooks.sql
@@ -1,0 +1,82 @@
+-- Webhook support migration
+-- Creates tables for webhook management and delivery tracking
+
+-- Webhooks table
+CREATE TABLE IF NOT EXISTS webhooks (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id UUID NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    url TEXT NOT NULL,
+    secret VARCHAR(64) NOT NULL,
+    events JSONB NOT NULL DEFAULT '[]',
+    headers JSONB DEFAULT '{}',
+    is_active BOOLEAN NOT NULL DEFAULT true,
+    description TEXT,
+    created_by UUID,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    deleted_at TIMESTAMP WITH TIME ZONE,
+    
+    CONSTRAINT fk_webhooks_organization FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE CASCADE,
+    CONSTRAINT fk_webhooks_created_by FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL
+);
+
+-- Create indexes for webhooks
+CREATE INDEX IF NOT EXISTS idx_webhooks_organization_id ON webhooks(organization_id);
+CREATE INDEX IF NOT EXISTS idx_webhooks_is_active ON webhooks(is_active) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_webhooks_events ON webhooks USING GIN (events);
+CREATE INDEX IF NOT EXISTS idx_webhooks_deleted_at ON webhooks(deleted_at) WHERE deleted_at IS NULL;
+
+-- Webhook deliveries table
+CREATE TABLE IF NOT EXISTS webhook_deliveries (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    webhook_id UUID NOT NULL,
+    event VARCHAR(100) NOT NULL,
+    payload JSONB NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'pending',
+    status_code INTEGER,
+    response TEXT,
+    error_message TEXT,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    next_retry_at TIMESTAMP WITH TIME ZONE,
+    delivered_at TIMESTAMP WITH TIME ZONE,
+    duration_ms INTEGER,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    
+    CONSTRAINT fk_webhook_deliveries_webhook FOREIGN KEY (webhook_id) REFERENCES webhooks(id) ON DELETE CASCADE,
+    CONSTRAINT chk_delivery_status CHECK (status IN ('pending', 'success', 'failed', 'retrying'))
+);
+
+-- Create indexes for webhook_deliveries
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_webhook_id ON webhook_deliveries(webhook_id);
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_status ON webhook_deliveries(status);
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_created_at ON webhook_deliveries(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_next_retry ON webhook_deliveries(next_retry_at) 
+    WHERE status IN ('pending', 'retrying') AND next_retry_at IS NOT NULL;
+
+-- Add comment for documentation
+COMMENT ON TABLE webhooks IS 'Stores webhook configurations for event-driven notifications';
+COMMENT ON TABLE webhook_deliveries IS 'Tracks individual webhook delivery attempts and their outcomes';
+
+-- Create function to update updated_at timestamp
+CREATE OR REPLACE FUNCTION update_webhook_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create triggers for updated_at
+DROP TRIGGER IF EXISTS trigger_webhooks_updated_at ON webhooks;
+CREATE TRIGGER trigger_webhooks_updated_at
+    BEFORE UPDATE ON webhooks
+    FOR EACH ROW
+    EXECUTE FUNCTION update_webhook_updated_at();
+
+DROP TRIGGER IF EXISTS trigger_webhook_deliveries_updated_at ON webhook_deliveries;
+CREATE TRIGGER trigger_webhook_deliveries_updated_at
+    BEFORE UPDATE ON webhook_deliveries
+    FOR EACH ROW
+    EXECUTE FUNCTION update_webhook_updated_at();


### PR DESCRIPTION
## Summary
This PR implements webhook support for event-driven integrations, as requested in issue #20.

## Features

### Webhook Management
- Full CRUD operations via REST API
- Subscribe to specific event types (server, alert, security, discovery)
- Custom headers support for authentication
- Secret rotation endpoint

### Event Types
| Category | Events |
|----------|--------|
| Server | `server.created`, `server.updated`, `server.deleted`, `server.status.up`, `server.status.down` |
| Alert | `alert.created`, `alert.resolved` |
| Security | `security.scan.started`, `security.scan.completed`, `security.vulnerability.found` |
| Discovery | `discovery.started`, `discovery.completed`, `discovery.server.found` |

### Security
- **HMAC-SHA256 signatures** for payload verification
- **Timestamp validation** (5-minute window) for replay attack prevention
- Secrets never exposed after initial creation
- Timing-safe signature comparison

### Delivery System
- Automatic retries with **exponential backoff** (1m → 5m → 15m → 1h → 2h)
- Maximum 5 retry attempts
- Delivery history tracking
- Success/failure statistics
- Test endpoint for webhook verification

### API Endpoints
```
POST   /api/v1/webhooks                  # Create webhook
GET    /api/v1/webhooks                  # List webhooks
GET    /api/v1/webhooks/:id              # Get webhook
PUT    /api/v1/webhooks/:id              # Update webhook
DELETE /api/v1/webhooks/:id              # Delete webhook
POST   /api/v1/webhooks/:id/rotate-secret # Rotate secret
POST   /api/v1/webhooks/:id/test         # Test webhook
GET    /api/v1/webhooks/:id/deliveries   # Get delivery history
GET    /api/v1/webhooks/:id/stats        # Get statistics
GET    /api/v1/webhook-events            # List available events
```

## Files Added
- `internal/webhook/models.go` - Data models and types
- `internal/webhook/repository.go` - Database operations
- `internal/webhook/service.go` - Business logic
- `internal/webhook/handler.go` - HTTP handlers
- `internal/webhook/client.go` - Verification utilities for receivers
- `internal/webhook/webhook_test.go` - Unit tests
- `internal/webhook/INTEGRATION.md` - Integration guide
- `migrations/003_add_webhooks.sql` - Database migration

## Usage Example

### Create a webhook:
```bash
curl -X POST http://localhost:8080/api/v1/webhooks \
  -H "Content-Type: application/json" \
  -d '{
    "name": "My Webhook",
    "url": "https://example.com/webhook",
    "events": ["alert.created", "server.status.down"]
  }'
```

### Verify incoming webhooks:
```go
client := webhook.NewClient(secret)
if err := client.VerifyRequest(r); err != nil {
    return err // Invalid signature
}
```

## Integration
See `INTEGRATION.md` for instructions on wiring webhooks into existing handlers.

Closes #20